### PR TITLE
fix: use facts to restart the correct service

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: restart systemd service
   systemd:
-    name: "{{ systemd_service.name }}"
+    name: "{{ systemd_service_unit_name }}"
     state: restarted
     daemon_reload: true
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,11 @@
       - systemd_service.name is defined
   tags: ['check_vars']
 
+- name: "set service name fact"
+  set_fact:
+    systemd_service_unit_name: "{{ systemd_service.name }}"
+    cacheable: false
+
 - name: creating systemd service
   include_tasks: common-service.yml
   when: systemd_service.docker is not defined or systemd_service.docker.image is not defined


### PR DESCRIPTION
ansible only registers the handler once, filled with the last value of
the variables encountered during playbook execution. This caused a lot
of issues as often times, the wrong service got restarted.

By using facts, ansible is forced to always fetch the current value